### PR TITLE
Get All Published Blogs ID

### DIFF
--- a/dto/sitemap.dto.go
+++ b/dto/sitemap.dto.go
@@ -1,0 +1,8 @@
+package dto
+
+import "time"
+
+type SitemapOutput struct {
+	ID        string
+	UpdatedAt time.Time
+}

--- a/handlers/blog.handler.go
+++ b/handlers/blog.handler.go
@@ -11,6 +11,7 @@ type BlogHandler interface {
 	SendBlogList(c *fiber.Ctx) error
 	SendPublishedBlog(c *fiber.Ctx) error
 	SendPublishedBlogs(c *fiber.Ctx) error
+	SendPublishedBlogsID(c *fiber.Ctx) error
 	SendBlogCreate(c *fiber.Ctx) error
 	SendCurrentUserBlogs(c *fiber.Ctx) error
 	SendPublishBlog(c *fiber.Ctx) error
@@ -65,6 +66,18 @@ func (handler *BlogHandlerImpl) SendPublishedBlog(c *fiber.Ctx) error {
 func (handler *BlogHandlerImpl) SendPublishedBlogs(c *fiber.Ctx) error {
 	// send only PUBLISHED and SAFE blogs
 	result, err := handler.BlogService.GetAllBlogs(true)
+	if err != nil {
+		return c.SendStatus(fiber.StatusInternalServerError)
+	}
+
+	return c.Status(fiber.StatusOK).JSON(&fiber.Map{
+		"result": result,
+	})
+}
+
+func (handler *BlogHandlerImpl) SendPublishedBlogsID(c *fiber.Ctx) error {
+	// send only PUBLISHED IDs
+	result, err := handler.BlogService.GetAllBlogsID()
 	if err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}

--- a/routes/blog.route.go
+++ b/routes/blog.route.go
@@ -14,6 +14,7 @@ func InitBlogRoute(server *fiber.App, handler handlers.BlogHandler) {
 	// drafted/unpublished blogs must only
 	// be available to its author scope.
 	blog.Get("/list", handler.SendPublishedBlogs)
+	blog.Get("/list/id", handler.SendPublishedBlogsID)
 	blog.Post("/get", handler.SendPublishedBlog)
 
 	blog.Get("/list/current", middlewares.ProtectedRoute, handler.SendCurrentUserBlogs)

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -9,6 +9,7 @@ import (
 
 type BlogService interface {
 	GetAllBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error)
+	GetAllBlogsID() ([]string, error)
 	GetBlogDetail(blogID string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(payload *inputs.CreateBlogInput, userID string) (*entities.Blog, error)
 	EditBlog(payload *inputs.UpdateBlogInput, userID string) error
@@ -30,6 +31,23 @@ func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool) ([]entities.Safe
 	}
 
 	return blogs, nil
+}
+
+func (service *BlogServiceImpl) GetAllBlogsID() ([]string, error) {
+	blogs, err := service.GetAllBlogs(true) // get all published blogs
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+
+	// only get the id, and append it to array if of string
+	for _, blog := range blogs {
+		ID := blog.ID
+		result = append(result, ID)
+	}
+
+	return result, nil
 }
 
 // GetPublishedBlogDetail retrieves a single SafeBlogAuthor entity from the database

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"resqiar.com-server/dto"
 	"resqiar.com-server/entities"
 	"resqiar.com-server/inputs"
 	"resqiar.com-server/repositories"
@@ -9,7 +10,7 @@ import (
 
 type BlogService interface {
 	GetAllBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error)
-	GetAllBlogsID() ([]string, error)
+	GetAllBlogsID() ([]dto.SitemapOutput, error)
 	GetBlogDetail(blogID string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(payload *inputs.CreateBlogInput, userID string) (*entities.Blog, error)
 	EditBlog(payload *inputs.UpdateBlogInput, userID string) error
@@ -33,18 +34,22 @@ func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool) ([]entities.Safe
 	return blogs, nil
 }
 
-func (service *BlogServiceImpl) GetAllBlogsID() ([]string, error) {
+func (service *BlogServiceImpl) GetAllBlogsID() ([]dto.SitemapOutput, error) {
 	blogs, err := service.GetAllBlogs(true) // get all published blogs
 	if err != nil {
 		return nil, err
 	}
 
-	var result []string
+	var result []dto.SitemapOutput
 
 	// only get the id, and append it to array if of string
 	for _, blog := range blogs {
-		ID := blog.ID
-		result = append(result, ID)
+		temp := dto.SitemapOutput{
+			ID:        blog.ID,
+			UpdatedAt: blog.UpdatedAt,
+		}
+
+		result = append(result, temp)
 	}
 
 	return result, nil

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -133,6 +133,9 @@ func (service *BlogServiceImpl) ChangeBlogPublish(payload *inputs.BlogIDInput, u
 		blog.PublishedAt = time.Time{}
 	}
 
+	// change the updated at to newest date
+	blog.UpdatedAt = time.Now()
+
 	// save back to the database
 	if err := service.Repository.SaveBlog(blog); err != nil {
 		return err

--- a/services/blog_test.go
+++ b/services/blog_test.go
@@ -97,6 +97,53 @@ func TestGetBlogs(t *testing.T) {
 	})
 }
 
+func TestGetBlogsID(t *testing.T) {
+	t.Run("Should return an array of published blog IDs", func(t *testing.T) {
+		published := true
+
+		expected := []entities.SafeBlogAuthor{
+			{
+				SafeBlog: entities.SafeBlog{
+					ID:          "example-of-id-1",
+					PublishedAt: time.Now(),
+				},
+			},
+			{
+				SafeBlog: entities.SafeBlog{
+					ID:          "example-of-id-2",
+					PublishedAt: time.Now(),
+				},
+			},
+		}
+
+		mock := blogRepoTest.Mock.On("GetBlogs", published).Return(expected, nil)
+
+		results, err := blogServiceTest.GetAllBlogsID()
+
+		assert.Nil(t, err)
+		assert.NotEmpty(t, results)
+		assert.Contains(t, results, "example-of-id-1")
+		assert.Contains(t, results, "example-of-id-2")
+		assert.IsType(t, []string{}, results)
+
+		t.Cleanup(func() {
+			// Cleanup mocking
+			mock.Unset()
+		})
+	})
+
+	t.Run("Should return an error if query fails", func(t *testing.T) {
+		published := true
+		blogRepoTest.Mock.On("GetBlogs", published).Return(nil, errors.New("Something went wrong"))
+
+		results, err := blogServiceTest.GetAllBlogsID()
+
+		assert.Nil(t, results)
+		assert.NotNil(t, err)
+		assert.Error(t, err)
+	})
+}
+
 func TestGetBlogDetail(t *testing.T) {
 	t.Run("Should return published blog detail", func(t *testing.T) {
 		blogID := "example-of-id"

--- a/services/blog_test.go
+++ b/services/blog_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"resqiar.com-server/dto"
 	"resqiar.com-server/entities"
 	"resqiar.com-server/inputs"
 	"resqiar.com-server/repositories"
@@ -104,14 +105,14 @@ func TestGetBlogsID(t *testing.T) {
 		expected := []entities.SafeBlogAuthor{
 			{
 				SafeBlog: entities.SafeBlog{
-					ID:          "example-of-id-1",
+					ID:          "example-of-id",
 					PublishedAt: time.Now(),
 				},
 			},
 			{
 				SafeBlog: entities.SafeBlog{
-					ID:          "example-of-id-2",
-					PublishedAt: time.Now(),
+					ID:          "example-of-id",
+					PublishedAt: time.Time{},
 				},
 			},
 		}
@@ -122,9 +123,12 @@ func TestGetBlogsID(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
-		assert.Contains(t, results, "example-of-id-1")
-		assert.Contains(t, results, "example-of-id-2")
-		assert.IsType(t, []string{}, results)
+		assert.IsType(t, []dto.SitemapOutput{}, results)
+
+		for _, result := range results {
+			assert.Equal(t, "example-of-id", result.ID)
+			assert.NotNil(t, result.UpdatedAt)
+		}
 
 		t.Cleanup(func() {
 			// Cleanup mocking


### PR DESCRIPTION

## Completing `api.resqiar.com/blog/list/id`

The purpose of this route is to serve as a sitemap and provide SEO-related functionality. It allows querying for the IDs of all published blogs on the platform. By utilizing this route, we can effectively communicate the content available on our platform to web crawlers, thereby increasing the visibility of our published blogs and enhancing their discoverability. This helps in optimizing search engine rankings and driving more traffic to our platform.

The route return an array of published blogs ID:
```json
{
  "result": [
    "qKqdrxicDyms",
    "zn74r5yotm06",
    "GLqKzhrRRQPc",
    "ZCN0VTR6W9Gp",
    "7XS8GbEXr799",
    "5XnJsJ2fZJSV",
    "NtuYr0jPInvl",
    "kMPjd5gyTLXR",
    "mQxYAdYWkLdr",
    "SYHbhuqdDfh9",
    "AFjO5QqensrA"
  ]
}
```