### PR TITLE
Data Ordering (ASC & DESC)

### DIFF
--- a/constants/order.constant.go
+++ b/constants/order.constant.go
@@ -1,0 +1,13 @@
+package constants
+
+type Order string
+
+const (
+	ASC  Order = "ASC"
+	DESC Order = "DESC"
+)
+
+var ValidOrders = map[string]struct{}{
+	string(ASC):  {},
+	string(DESC): {},
+}

--- a/handlers/blog.handler.go
+++ b/handlers/blog.handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"resqiar.com-server/constants"
 	"resqiar.com-server/inputs"
 	"resqiar.com-server/services"
 
@@ -27,7 +28,14 @@ type BlogHandlerImpl struct {
 }
 
 func (handler *BlogHandlerImpl) SendBlogList(c *fiber.Ctx) error {
-	result, err := handler.BlogService.GetAllBlogs(false)
+	var qOrder string = c.Query("order", "DESC")
+
+	// if order query does not exist in the map, set to default value
+	if _, exist := constants.ValidOrders[qOrder]; !exist {
+		qOrder = string(constants.DESC)
+	}
+
+	result, err := handler.BlogService.GetAllBlogs(false, constants.Order(qOrder))
 	if err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
@@ -65,8 +73,15 @@ func (handler *BlogHandlerImpl) SendPublishedBlog(c *fiber.Ctx) error {
 }
 
 func (handler *BlogHandlerImpl) SendPublishedBlogs(c *fiber.Ctx) error {
+	var qOrder string = c.Query("order", "DESC")
+
+	// if order query does not exist in the map, set to default value
+	if _, exist := constants.ValidOrders[qOrder]; !exist {
+		qOrder = string(constants.DESC)
+	}
+
 	// send only PUBLISHED and SAFE blogs
-	result, err := handler.BlogService.GetAllBlogs(true)
+	result, err := handler.BlogService.GetAllBlogs(true, constants.Order(qOrder))
 	if err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
@@ -123,7 +138,14 @@ func (handler *BlogHandlerImpl) SendBlogCreate(c *fiber.Ctx) error {
 func (handler *BlogHandlerImpl) SendCurrentUserBlogs(c *fiber.Ctx) error {
 	userID := c.Locals("userID")
 
-	result, err := handler.BlogService.GetCurrentUserBlogs(userID.(string))
+	var qOrder string = c.Query("order", "DESC")
+
+	// if order query does not exist in the map, set to default value
+	if _, exist := constants.ValidOrders[qOrder]; !exist {
+		qOrder = string(constants.DESC)
+	}
+
+	result, err := handler.BlogService.GetCurrentUserBlogs(userID.(string), constants.Order(qOrder))
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"error": err,

--- a/repositories/blog.repo.go
+++ b/repositories/blog.repo.go
@@ -11,7 +11,7 @@ import (
 )
 
 type BlogRepository interface {
-	GetBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error)
+	GetBlogs(onlyPublished bool, desc bool) ([]entities.SafeBlogAuthor, error)
 	GetBlog(blogID string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(input *entities.Blog) (*entities.Blog, error)
 	UpdateBlog(blogID string, safe *inputs.SafeUpdateBlogInput) error
@@ -31,7 +31,7 @@ func InitBlogRepo(db *gorm.DB) BlogRepository {
 	}
 }
 
-func (repo *BlogRepoImpl) GetBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error) {
+func (repo *BlogRepoImpl) GetBlogs(onlyPublished bool, orderDesc bool) ([]entities.SafeBlogAuthor, error) {
 	var blogs []entities.SafeBlogAuthor
 
 	query := repo.db.Model(&entities.Blog{})
@@ -47,6 +47,12 @@ func (repo *BlogRepoImpl) GetBlogs(onlyPublished bool) ([]entities.SafeBlogAutho
 	// If onlyPublished is true, add a condition to retrieve only published blogs
 	if onlyPublished {
 		query.Where("blogs.published = ?", true)
+	}
+
+	if orderDesc {
+		query.Order("updated_at DESC")
+	} else {
+		query.Order("updated_at ASC")
 	}
 
 	// Execute the query and retrieve the rows

--- a/repositories/blog.repo.mock.go
+++ b/repositories/blog.repo.mock.go
@@ -60,8 +60,8 @@ func (repo *BlogRepoMock) GetByIDAndAuthor(blogID string, userID string) (*entit
 	return nil, args.Error(1)
 }
 
-func (repo *BlogRepoMock) GetCurrentUserBlogs(userID string) ([]entities.Blog, error) {
-	args := repo.Mock.Called(userID)
+func (repo *BlogRepoMock) GetCurrentUserBlogs(userID string, desc bool) ([]entities.Blog, error) {
+	args := repo.Mock.Called(userID, desc)
 
 	if args.Get(0) != nil {
 		return args.Get(0).([]entities.Blog), args.Error(1)

--- a/repositories/blog.repo.mock.go
+++ b/repositories/blog.repo.mock.go
@@ -10,8 +10,8 @@ type BlogRepoMock struct {
 	Mock mock.Mock
 }
 
-func (repo *BlogRepoMock) GetBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error) {
-	args := repo.Mock.Called(onlyPublished)
+func (repo *BlogRepoMock) GetBlogs(onlyPublished bool, desc bool) ([]entities.SafeBlogAuthor, error) {
+	args := repo.Mock.Called(onlyPublished, desc)
 
 	if args.Get(0) != nil {
 		return args.Get(0).([]entities.SafeBlogAuthor), args.Error(1)

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -1,20 +1,22 @@
 package services
 
 import (
+	"time"
+
+	"resqiar.com-server/constants"
 	"resqiar.com-server/dto"
 	"resqiar.com-server/entities"
 	"resqiar.com-server/inputs"
 	"resqiar.com-server/repositories"
-	"time"
 )
 
 type BlogService interface {
-	GetAllBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error)
+	GetAllBlogs(onlyPublished bool, order constants.Order) ([]entities.SafeBlogAuthor, error)
 	GetAllBlogsID() ([]dto.SitemapOutput, error)
 	GetBlogDetail(blogID string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(payload *inputs.CreateBlogInput, userID string) (*entities.Blog, error)
 	EditBlog(payload *inputs.UpdateBlogInput, userID string) error
-	GetCurrentUserBlogs(userID string) ([]entities.Blog, error)
+	GetCurrentUserBlogs(userID string, order constants.Order) ([]entities.Blog, error)
 	GetCurrentUserBlog(blogID string, userID string) (*entities.Blog, error)
 	ChangeBlogPublish(payload *inputs.BlogIDInput, userID string, publishState bool) error
 }
@@ -26,9 +28,16 @@ type BlogServiceImpl struct {
 // GetAllBlogs retrieves a list of SafeBlogAuthor entities from the database.
 // If onlyPublished is true, it retrieves only the published blogs, otherwise everything.
 // It returns the list of blogs and any error encountered during the process.
-func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error) {
-	// Get all only-published blogs with the desc order (true)
-	blogs, err := service.Repository.GetBlogs(onlyPublished, true)
+func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool, dataOrder constants.Order) ([]entities.SafeBlogAuthor, error) {
+	// default data-order to true (DESC)
+	order := true
+
+	if dataOrder == constants.ASC {
+		order = false
+	}
+
+	// Get all only-published blogs with the desc order true/false (default to desc / true)
+	blogs, err := service.Repository.GetBlogs(onlyPublished, order)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +46,9 @@ func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool) ([]entities.Safe
 }
 
 func (service *BlogServiceImpl) GetAllBlogsID() ([]dto.SitemapOutput, error) {
-	blogs, err := service.GetAllBlogs(true) // get all published blogs
+	// get all published blogs ID
+	// always set to DESC
+	blogs, err := service.GetAllBlogs(true, constants.DESC)
 	if err != nil {
 		return nil, err
 	}
@@ -113,8 +124,15 @@ func (service *BlogServiceImpl) EditBlog(payload *inputs.UpdateBlogInput, userID
 	return nil
 }
 
-func (service *BlogServiceImpl) GetCurrentUserBlogs(userID string) ([]entities.Blog, error) {
-	blogs, err := service.Repository.GetCurrentUserBlogs(userID, true)
+func (service *BlogServiceImpl) GetCurrentUserBlogs(userID string, dataOrder constants.Order) ([]entities.Blog, error) {
+	// default data-order to true (DESC)
+	order := true
+
+	if dataOrder == constants.ASC {
+		order = false
+	}
+
+	blogs, err := service.Repository.GetCurrentUserBlogs(userID, order)
 	if err != nil {
 		return nil, err
 	}

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -27,7 +27,8 @@ type BlogServiceImpl struct {
 // If onlyPublished is true, it retrieves only the published blogs, otherwise everything.
 // It returns the list of blogs and any error encountered during the process.
 func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool) ([]entities.SafeBlogAuthor, error) {
-	blogs, err := service.Repository.GetBlogs(onlyPublished)
+	// Get all only-published blogs with the desc order (true)
+	blogs, err := service.Repository.GetBlogs(onlyPublished, true)
 	if err != nil {
 		return nil, err
 	}

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -114,7 +114,7 @@ func (service *BlogServiceImpl) EditBlog(payload *inputs.UpdateBlogInput, userID
 }
 
 func (service *BlogServiceImpl) GetCurrentUserBlogs(userID string) ([]entities.Blog, error) {
-	blogs, err := service.Repository.GetCurrentUserBlogs(userID)
+	blogs, err := service.Repository.GetCurrentUserBlogs(userID, true)
 	if err != nil {
 		return nil, err
 	}

--- a/services/blog_test.go
+++ b/services/blog_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"resqiar.com-server/constants"
 	"resqiar.com-server/dto"
 	"resqiar.com-server/entities"
 	"resqiar.com-server/inputs"
@@ -36,7 +37,7 @@ func TestGetBlogs(t *testing.T) {
 
 		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
-		results, err := blogServiceTest.GetAllBlogs(published)
+		results, err := blogServiceTest.GetAllBlogs(published, constants.DESC)
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
@@ -66,7 +67,7 @@ func TestGetBlogs(t *testing.T) {
 
 		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
-		results, err := blogServiceTest.GetAllBlogs(published)
+		results, err := blogServiceTest.GetAllBlogs(published, constants.DESC)
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
@@ -88,7 +89,7 @@ func TestGetBlogs(t *testing.T) {
 
 		blogRepoTest.Mock.On("GetBlogs", published, true).Return(nil, errors.New("Something went wrong"))
 
-		results, err := blogServiceTest.GetAllBlogs(published)
+		results, err := blogServiceTest.GetAllBlogs(published, constants.DESC)
 
 		assert.Nil(t, results)
 		assert.NotNil(t, err)
@@ -117,7 +118,7 @@ func TestGetBlogs(t *testing.T) {
 
 		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
-		results, err := blogServiceTest.GetAllBlogs(published)
+		results, err := blogServiceTest.GetAllBlogs(published, constants.DESC)
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
@@ -128,6 +129,44 @@ func TestGetBlogs(t *testing.T) {
 
 		// assert if the mock function is called with DESC == true
 		blogRepoTest.Mock.AssertCalled(t, "GetBlogs", published, true)
+
+		t.Cleanup(func() {
+			// Cleanup mocking
+			mock.Unset()
+		})
+	})
+
+	t.Run("Should return result in ASC order", func(t *testing.T) {
+		published := true
+
+		expected := []entities.SafeBlogAuthor{
+			{
+				SafeBlog: entities.SafeBlog{
+					UpdatedAt:   time.Now().AddDate(0, 0, -7), // last week
+					PublishedAt: time.Now(),
+				},
+			},
+			{
+				SafeBlog: entities.SafeBlog{
+					UpdatedAt:   time.Now().AddDate(0, 0, -1), // yesterday
+					PublishedAt: time.Now(),
+				},
+			},
+		}
+
+		mock := blogRepoTest.Mock.On("GetBlogs", published, false).Return(expected, nil)
+
+		results, err := blogServiceTest.GetAllBlogs(published, constants.ASC)
+
+		assert.Nil(t, err)
+		assert.NotEmpty(t, results)
+		assert.Equal(t, results, expected)
+
+		// assert if the sortedResults are indeed ASC order
+		assert.True(t, results[0].UpdatedAt.Before(results[1].UpdatedAt))
+
+		// assert if the mock function is called with DESC == false
+		blogRepoTest.Mock.AssertCalled(t, "GetBlogs", published, false)
 
 		t.Cleanup(func() {
 			// Cleanup mocking
@@ -409,7 +448,7 @@ func TestGetCurrentUserBlogs(t *testing.T) {
 
 		mock := blogRepoTest.Mock.On("GetCurrentUserBlogs", userID, true).Return(expected, nil)
 
-		results, err := blogServiceTest.GetCurrentUserBlogs(userID)
+		results, err := blogServiceTest.GetCurrentUserBlogs(userID, constants.DESC)
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
@@ -426,7 +465,7 @@ func TestGetCurrentUserBlogs(t *testing.T) {
 
 		mock := blogRepoTest.Mock.On("GetCurrentUserBlogs", userID, true).Return(nil, errors.New("Record not found"))
 
-		results, err := blogServiceTest.GetCurrentUserBlogs(userID)
+		results, err := blogServiceTest.GetCurrentUserBlogs(userID, constants.DESC)
 
 		assert.Nil(t, results)
 		assert.NotNil(t, err)
@@ -452,7 +491,7 @@ func TestGetCurrentUserBlogs(t *testing.T) {
 
 		mock := blogRepoTest.Mock.On("GetCurrentUserBlogs", userID, true).Return(expected, nil)
 
-		results, err := blogServiceTest.GetCurrentUserBlogs(userID)
+		results, err := blogServiceTest.GetCurrentUserBlogs(userID, constants.DESC)
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
@@ -463,6 +502,38 @@ func TestGetCurrentUserBlogs(t *testing.T) {
 
 		// assert if the mock function is called with DESC == true
 		blogRepoTest.Mock.AssertCalled(t, "GetCurrentUserBlogs", userID, true)
+
+		t.Cleanup(func() {
+			// Cleanup mocking
+			mock.Unset()
+		})
+	})
+
+	t.Run("Should return result in ASC order", func(t *testing.T) {
+		userID := "example-of-id"
+
+		expected := []entities.Blog{
+			{
+				UpdatedAt: time.Now().AddDate(0, 0, -7), // last week
+			},
+			{
+				UpdatedAt: time.Now().AddDate(0, 0, -1), // yesterday
+			},
+		}
+
+		mock := blogRepoTest.Mock.On("GetCurrentUserBlogs", userID, false).Return(expected, nil)
+
+		results, err := blogServiceTest.GetCurrentUserBlogs(userID, constants.ASC)
+
+		assert.Nil(t, err)
+		assert.NotEmpty(t, results)
+		assert.Equal(t, results, expected)
+
+		// assert if the sortedResults are indeed ASC order
+		assert.True(t, results[0].UpdatedAt.Before(results[1].UpdatedAt))
+
+		// assert if the mock function is called with DESC == false
+		blogRepoTest.Mock.AssertCalled(t, "GetCurrentUserBlogs", userID, false)
 
 		t.Cleanup(func() {
 			// Cleanup mocking

--- a/services/blog_test.go
+++ b/services/blog_test.go
@@ -34,7 +34,7 @@ func TestGetBlogs(t *testing.T) {
 			},
 		}
 
-		mock := blogRepoTest.Mock.On("GetBlogs", published).Return(expected, nil)
+		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
 		results, err := blogServiceTest.GetAllBlogs(published)
 
@@ -64,7 +64,7 @@ func TestGetBlogs(t *testing.T) {
 			},
 		}
 
-		mock := blogRepoTest.Mock.On("GetBlogs", published).Return(expected, nil)
+		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
 		results, err := blogServiceTest.GetAllBlogs(published)
 
@@ -86,7 +86,7 @@ func TestGetBlogs(t *testing.T) {
 	t.Run("Should return an error query fails", func(t *testing.T) {
 		published := false
 
-		blogRepoTest.Mock.On("GetBlogs", published).Return(nil, errors.New("Something went wrong"))
+		blogRepoTest.Mock.On("GetBlogs", published, true).Return(nil, errors.New("Something went wrong"))
 
 		results, err := blogServiceTest.GetAllBlogs(published)
 
@@ -94,7 +94,45 @@ func TestGetBlogs(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Error(t, err)
 
-		blogRepoTest.Mock.AssertCalled(t, "GetBlogs", published)
+		blogRepoTest.Mock.AssertCalled(t, "GetBlogs", published, true)
+	})
+
+	t.Run("Should return result in DESC order", func(t *testing.T) {
+		published := true
+
+		expected := []entities.SafeBlogAuthor{
+			{
+				SafeBlog: entities.SafeBlog{
+					UpdatedAt:   time.Now().AddDate(0, 0, -1), // yesterday
+					PublishedAt: time.Now(),
+				},
+			},
+			{
+				SafeBlog: entities.SafeBlog{
+					UpdatedAt:   time.Now().AddDate(0, 0, -7), // last week
+					PublishedAt: time.Now(),
+				},
+			},
+		}
+
+		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
+
+		results, err := blogServiceTest.GetAllBlogs(published)
+
+		assert.Nil(t, err)
+		assert.NotEmpty(t, results)
+		assert.Equal(t, results, expected)
+
+		// assert if the sortedResults are indeed DESC order
+		assert.True(t, results[0].UpdatedAt.After(results[1].UpdatedAt))
+
+		// assert if the mock function is called with DESC == true
+		blogRepoTest.Mock.AssertCalled(t, "GetBlogs", published, true)
+
+		t.Cleanup(func() {
+			// Cleanup mocking
+			mock.Unset()
+		})
 	})
 }
 
@@ -117,7 +155,7 @@ func TestGetBlogsID(t *testing.T) {
 			},
 		}
 
-		mock := blogRepoTest.Mock.On("GetBlogs", published).Return(expected, nil)
+		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
 		results, err := blogServiceTest.GetAllBlogsID()
 
@@ -138,7 +176,7 @@ func TestGetBlogsID(t *testing.T) {
 
 	t.Run("Should return an error if query fails", func(t *testing.T) {
 		published := true
-		blogRepoTest.Mock.On("GetBlogs", published).Return(nil, errors.New("Something went wrong"))
+		blogRepoTest.Mock.On("GetBlogs", published, true).Return(nil, errors.New("Something went wrong"))
 
 		results, err := blogServiceTest.GetAllBlogsID()
 


### PR DESCRIPTION
Add a data ordering to these routes:

1. `/blog/list`
2. `/blog/list/current`

To get asc/desc order (always default to DESC), we can add `order` query to above routes, for example `/blog/list?order=ASC` or `/blog/list?order=DESC`. **All values of the query must be in uppercase**.