### PR TITLE
19 change public url to title slug instead of nanoid

### DIFF
--- a/dto/sitemap.dto.go
+++ b/dto/sitemap.dto.go
@@ -3,6 +3,7 @@ package dto
 import "time"
 
 type SitemapOutput struct {
-	ID        string
-	UpdatedAt time.Time
+	AuthorUsername string
+	Slug           string
+	UpdatedAt      time.Time
 }

--- a/entities/blog.entity.go
+++ b/entities/blog.entity.go
@@ -9,6 +9,7 @@ import (
 
 type Blog struct {
 	ID          string `gorm:"type:text; primaryKey; unique; not null"`
+	Slug        string `gorm:"type:varchar(100)"`
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	PublishedAt time.Time

--- a/entities/safe-blog.entity.go
+++ b/entities/safe-blog.entity.go
@@ -4,6 +4,7 @@ import "time"
 
 type SafeBlog struct {
 	ID          string
+	Slug        string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	PublishedAt time.Time

--- a/handlers/blog.handler.go
+++ b/handlers/blog.handler.go
@@ -46,9 +46,10 @@ func (handler *BlogHandlerImpl) SendBlogList(c *fiber.Ctx) error {
 }
 
 func (handler *BlogHandlerImpl) SendPublishedBlog(c *fiber.Ctx) error {
-	blogID := c.Params("id")
+	blogAuthor := c.Params("author")
+	blogSlug := c.Params("slug")
 
-	result, err := handler.BlogService.GetBlogDetail(blogID, true)
+	result, err := handler.BlogService.GetBlogDetail("", blogAuthor, blogSlug, true)
 	if err != nil {
 		return c.SendStatus(fiber.StatusNotFound)
 	}
@@ -248,7 +249,7 @@ func (handler *BlogHandlerImpl) SendMyBlog(c *fiber.Ctx) error {
 		})
 	}
 
-	blog, err := handler.BlogService.GetBlogDetail(payload.ID, false)
+	blog, err := handler.BlogService.GetBlogDetail(payload.ID, "", "", false)
 	if err != nil {
 		return c.SendStatus(fiber.StatusNotFound)
 	}

--- a/handlers/blog.handler.go
+++ b/handlers/blog.handler.go
@@ -12,7 +12,7 @@ type BlogHandler interface {
 	SendBlogList(c *fiber.Ctx) error
 	SendPublishedBlog(c *fiber.Ctx) error
 	SendPublishedBlogs(c *fiber.Ctx) error
-	SendPublishedBlogsID(c *fiber.Ctx) error
+	SendPublishedSlugs(c *fiber.Ctx) error
 	SendBlogCreate(c *fiber.Ctx) error
 	SendCurrentUserBlogs(c *fiber.Ctx) error
 	SendCurrentUserBlog(c *fiber.Ctx) error
@@ -78,9 +78,9 @@ func (handler *BlogHandlerImpl) SendPublishedBlogs(c *fiber.Ctx) error {
 	})
 }
 
-func (handler *BlogHandlerImpl) SendPublishedBlogsID(c *fiber.Ctx) error {
+func (handler *BlogHandlerImpl) SendPublishedSlugs(c *fiber.Ctx) error {
 	// send only PUBLISHED IDs
-	result, err := handler.BlogService.GetAllBlogsID()
+	result, err := handler.BlogService.GetAllSlugs()
 	if err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}

--- a/libs/module-init.lib.go
+++ b/libs/module-init.lib.go
@@ -21,7 +21,7 @@ func ModuleInit(server *fiber.App, DB *gorm.DB) {
 		Repository:  userRepository,
 		UtilService: &utilService,
 	}
-	blogService := services.BlogServiceImpl{Repository: blogRepository}
+	blogService := services.BlogServiceImpl{UtilService: &utilService, Repository: blogRepository}
 	authService := services.AuthServiceImpl{}
 
 	// Init handlers

--- a/repositories/blog.repo.go
+++ b/repositories/blog.repo.go
@@ -14,7 +14,7 @@ import (
 
 type BlogRepository interface {
 	GetBlogs(onlyPublished bool, desc bool) ([]entities.SafeBlogAuthor, error)
-	GetBlog(blogID string, published bool) (*entities.SafeBlogAuthor, error)
+	GetBlog(useID string, blogAuthor string, blogID string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(input *entities.Blog) (*entities.Blog, error)
 	UpdateBlog(blogID string, safe *inputs.SafeUpdateBlogInput) error
 	GetByIDAndAuthor(blogID string, userID string) (*entities.Blog, error)
@@ -103,24 +103,34 @@ func (repo *BlogRepoImpl) GetBlogs(onlyPublished bool, orderDesc bool) ([]entiti
 	return blogs, nil
 }
 
-func (repo *BlogRepoImpl) GetBlog(blogID string, published bool) (*entities.SafeBlogAuthor, error) {
+func (repo *BlogRepoImpl) GetBlog(useID string, blogAuthor string, blogSlug string, published bool) (*entities.SafeBlogAuthor, error) {
 	var blog entities.SafeBlogAuthor
+	var condition string
+	var args []interface{}
 
 	// Define SELECT and JOIN for database query operations
 	BLOG_SELECT_SQL := "blogs.id, blogs.slug, blogs.created_at, blogs.updated_at, blogs.published_at, blogs.title, blogs.summary, blogs.content, blogs.cover_url, blogs.author_id, "
 	AUTHOR_SELECT_SQL := "users.id AS author_id, users.username AS author_username, users.created_at AS author_created_at, users.bio AS author_bio, users.picture_url AS author_picture_url, users.is_tester AS author_is_tester"
 	JOIN_SQL := "JOIN users ON blogs.author_id = users.id"
 
-	// Execute the query and retrieve the rows
 	result := repo.db.Model(&entities.Blog{}).
 		Select(BLOG_SELECT_SQL + AUTHOR_SELECT_SQL).
 		Joins(JOIN_SQL)
 
-	if published {
-		result.Where("blogs.id = ? AND published = ?", blogID, true)
+	if useID != "" {
+		condition = "blogs.ID = ?" // use ID instead of slug
+		args = []interface{}{useID}
 	} else {
-		result.Where("blogs.id = ?", blogID)
+		condition = "blogs.slug = ? AND users.username = ?" // use slug and username
+		args = []interface{}{blogSlug, blogAuthor}
 	}
+
+	if published {
+		condition += " AND published = ?"
+		args = append(args, true)
+	}
+
+	result.Where(condition, args...)
 
 	// Check for any errors during query execution
 	if result.Error != nil {

--- a/repositories/blog.repo.mock.go
+++ b/repositories/blog.repo.mock.go
@@ -20,8 +20,8 @@ func (repo *BlogRepoMock) GetBlogs(onlyPublished bool, desc bool) ([]entities.Sa
 	return nil, args.Error(1)
 }
 
-func (repo *BlogRepoMock) GetBlog(blogID string, published bool) (*entities.SafeBlogAuthor, error) {
-	args := repo.Mock.Called(blogID, published)
+func (repo *BlogRepoMock) GetBlog(useID string, blogAuthor string, blogSlug string, published bool) (*entities.SafeBlogAuthor, error) {
+	args := repo.Mock.Called(useID, blogAuthor, blogSlug, published)
 
 	if args.Get(0) != nil {
 		return args.Get(0).(*entities.SafeBlogAuthor), args.Error(1)
@@ -62,6 +62,16 @@ func (repo *BlogRepoMock) GetByIDAndAuthor(blogID string, userID string) (*entit
 
 func (repo *BlogRepoMock) GetCurrentUserBlogs(userID string, desc bool) ([]entities.Blog, error) {
 	args := repo.Mock.Called(userID, desc)
+
+	if args.Get(0) != nil {
+		return args.Get(0).([]entities.Blog), args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+func (repo *BlogRepoMock) GetCurrentUserSlugs(slug string, userID string) ([]entities.Blog, error) {
+	args := repo.Mock.Called(slug, userID)
 
 	if args.Get(0) != nil {
 		return args.Get(0).([]entities.Blog), args.Error(1)

--- a/routes/blog.route.go
+++ b/routes/blog.route.go
@@ -14,7 +14,7 @@ func InitBlogRoute(server *fiber.App, handler handlers.BlogHandler) {
 	// drafted/unpublished blogs must only
 	// be available to its author scope.
 	blog.Get("/list", handler.SendPublishedBlogs)
-	blog.Get("/list/id", handler.SendPublishedBlogsID)
+	blog.Get("/list/slug", handler.SendPublishedSlugs)
 	blog.Get("/get/:author/:slug", handler.SendPublishedBlog)
 
 	blog.Post("/list/current", middlewares.ProtectedRoute, handler.SendCurrentUserBlogs)

--- a/routes/blog.route.go
+++ b/routes/blog.route.go
@@ -15,7 +15,7 @@ func InitBlogRoute(server *fiber.App, handler handlers.BlogHandler) {
 	// be available to its author scope.
 	blog.Get("/list", handler.SendPublishedBlogs)
 	blog.Get("/list/id", handler.SendPublishedBlogsID)
-	blog.Get("/get/:id", handler.SendPublishedBlog)
+	blog.Get("/get/:author/:slug", handler.SendPublishedBlog)
 
 	blog.Post("/list/current", middlewares.ProtectedRoute, handler.SendCurrentUserBlogs)
 	blog.Post("/get/preview", middlewares.ProtectedRoute, handler.SendCurrentUserBlog)

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -14,7 +14,7 @@ import (
 type BlogService interface {
 	GetAllBlogs(onlyPublished bool, order constants.Order) ([]entities.SafeBlogAuthor, error)
 	GetAllBlogsID() ([]dto.SitemapOutput, error)
-	GetBlogDetail(blogID string, published bool) (*entities.SafeBlogAuthor, error)
+	GetBlogDetail(useID string, blogAuthor string, blogSlug string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(payload *inputs.CreateBlogInput, userID string) (*entities.Blog, error)
 	EditBlog(payload *inputs.UpdateBlogInput, userID string) error
 	GetCurrentUserBlogs(userID string, order constants.Order) ([]entities.Blog, error)
@@ -74,8 +74,8 @@ func (service *BlogServiceImpl) GetAllBlogsID() ([]dto.SitemapOutput, error) {
 // based on the provided blogID.
 // It returns the retrieved blog and any error encountered during the process.
 // If no blog is found or an error occurs, it returns an appropriate error.
-func (service *BlogServiceImpl) GetBlogDetail(blogID string, published bool) (*entities.SafeBlogAuthor, error) {
-	blog, err := service.Repository.GetBlog(blogID, published)
+func (service *BlogServiceImpl) GetBlogDetail(useID string, blogAuthor string, blogSlug string, published bool) (*entities.SafeBlogAuthor, error) {
+	blog, err := service.Repository.GetBlog(useID, blogAuthor, blogSlug, published)
 	if err != nil {
 		return nil, err
 	}

--- a/services/blog.service.go
+++ b/services/blog.service.go
@@ -13,7 +13,7 @@ import (
 
 type BlogService interface {
 	GetAllBlogs(onlyPublished bool, order constants.Order) ([]entities.SafeBlogAuthor, error)
-	GetAllBlogsID() ([]dto.SitemapOutput, error)
+	GetAllSlugs() ([]dto.SitemapOutput, error)
 	GetBlogDetail(useID string, blogAuthor string, blogSlug string, published bool) (*entities.SafeBlogAuthor, error)
 	CreateBlog(payload *inputs.CreateBlogInput, userID string) (*entities.Blog, error)
 	EditBlog(payload *inputs.UpdateBlogInput, userID string) error
@@ -47,7 +47,7 @@ func (service *BlogServiceImpl) GetAllBlogs(onlyPublished bool, dataOrder consta
 	return blogs, nil
 }
 
-func (service *BlogServiceImpl) GetAllBlogsID() ([]dto.SitemapOutput, error) {
+func (service *BlogServiceImpl) GetAllSlugs() ([]dto.SitemapOutput, error) {
 	// get all published blogs ID
 	// always set to DESC
 	blogs, err := service.GetAllBlogs(true, constants.DESC)
@@ -60,8 +60,9 @@ func (service *BlogServiceImpl) GetAllBlogsID() ([]dto.SitemapOutput, error) {
 	// only get the id, and append it to array if of string
 	for _, blog := range blogs {
 		temp := dto.SitemapOutput{
-			ID:        blog.ID,
-			UpdatedAt: blog.UpdatedAt,
+			Slug:           blog.Slug,
+			AuthorUsername: blog.Author.Username,
+			UpdatedAt:      blog.UpdatedAt,
 		}
 
 		result = append(result, temp)

--- a/services/blog_test.go
+++ b/services/blog_test.go
@@ -176,35 +176,42 @@ func TestGetBlogs(t *testing.T) {
 	})
 }
 
-func TestGetBlogsID(t *testing.T) {
-	t.Run("Should return an array of published blog IDs", func(t *testing.T) {
+func TestGetAllSlugs(t *testing.T) {
+	t.Run("Should return an array of published blogs with AuthorUsername, Slug, and UpdatedAt", func(t *testing.T) {
 		published := true
 
 		expected := []entities.SafeBlogAuthor{
 			{
 				SafeBlog: entities.SafeBlog{
-					ID:          "example-of-id",
+					Slug:        "example-of-slug",
 					PublishedAt: time.Now(),
+				},
+				Author: entities.SafeUser{
+					Username: "User123",
 				},
 			},
 			{
 				SafeBlog: entities.SafeBlog{
-					ID:          "example-of-id",
+					Slug:        "example-of-slug",
 					PublishedAt: time.Time{},
+				},
+				Author: entities.SafeUser{
+					Username: "User123",
 				},
 			},
 		}
 
 		mock := blogRepoTest.Mock.On("GetBlogs", published, true).Return(expected, nil)
 
-		results, err := blogServiceTest.GetAllBlogsID()
+		results, err := blogServiceTest.GetAllSlugs()
 
 		assert.Nil(t, err)
 		assert.NotEmpty(t, results)
 		assert.IsType(t, []dto.SitemapOutput{}, results)
 
 		for _, result := range results {
-			assert.Equal(t, "example-of-id", result.ID)
+			assert.Equal(t, "example-of-slug", result.Slug)
+			assert.Equal(t, "User123", result.AuthorUsername)
 			assert.NotNil(t, result.UpdatedAt)
 		}
 
@@ -218,7 +225,7 @@ func TestGetBlogsID(t *testing.T) {
 		published := true
 		blogRepoTest.Mock.On("GetBlogs", published, true).Return(nil, errors.New("Something went wrong"))
 
-		results, err := blogServiceTest.GetAllBlogsID()
+		results, err := blogServiceTest.GetAllSlugs()
 
 		assert.Nil(t, results)
 		assert.NotNil(t, err)

--- a/services/user_test.go
+++ b/services/user_test.go
@@ -12,8 +12,8 @@ import (
 
 var userRepo = &repositories.UserRepoMock{}
 var userService = UserServiceImpl{
-	Repository:  userRepo,
 	UtilService: &utilService,
+	Repository:  userRepo,
 }
 
 func TestRegisterUser(t *testing.T) {

--- a/services/util.service.go
+++ b/services/util.service.go
@@ -10,17 +10,23 @@ import (
 
 type UtilService interface {
 	FormatUsername(name string) string
+	FormatToURL(value string) string
 	GenerateRandomID(length int) string
 	ValidateInput(payload any) string
 }
 
 type UtilServiceImpl struct{}
 
+var (
+	removeNonAlphaNumRegex    = regexp.MustCompile("[^ a-zA-Z0-9]")
+	removeMultipleSpacesRegex = regexp.MustCompile(`\s+`)
+)
+
 func (service *UtilServiceImpl) FormatUsername(name string) string {
 	// remove any non-alphanumeric characters from the string
 	// example "?-_!" should be ""
 	// example "a?!;';';'b" should be "ab"
-	validChars := regexp.MustCompile("[^ a-zA-Z0-9]").ReplaceAllString(name, "")
+	validChars := removeNonAlphaNumRegex.ReplaceAllString(name, "")
 	formatted := validChars
 
 	// trim spaces
@@ -28,7 +34,7 @@ func (service *UtilServiceImpl) FormatUsername(name string) string {
 
 	// trim spaces between chars to maxed only one space
 	// example "a       b" should be "a b"
-	singleSpace := regexp.MustCompile(`\s+`).ReplaceAllString(formatted, " ")
+	singleSpace := removeMultipleSpacesRegex.ReplaceAllString(formatted, " ")
 	formatted = singleSpace
 
 	// format name to lowercase
@@ -37,6 +43,15 @@ func (service *UtilServiceImpl) FormatUsername(name string) string {
 	// format name to replace all spaces into _ (underscore)
 	formatted = strings.ReplaceAll(formatted, " ", "_")
 
+	return formatted
+}
+
+func (service *UtilServiceImpl) FormatToURL(value string) string {
+	formatted := removeNonAlphaNumRegex.ReplaceAllString(value, "")
+	formatted = strings.ToLower(formatted)
+	formatted = strings.TrimSpace(formatted)
+	formatted = removeMultipleSpacesRegex.ReplaceAllString(formatted, " ")
+	formatted = strings.ReplaceAll(formatted, " ", "-")
 	return formatted
 }
 

--- a/services/util_test.go
+++ b/services/util_test.go
@@ -39,6 +39,34 @@ func TestFormatUsername(t *testing.T) {
 	}
 }
 
+func TestFormatToURL(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"Exploring OAuth2 Protocol: What, Why, and How?", "exploring-oauth2-protocol-what-why-and-how"},
+		{"					Exploring OAuth2 Protocol: What, Why, and How?		", "exploring-oauth2-protocol-what-why-and-how"},
+		{"					Exploring OAuth2				 Protocol: What, Why, and How?		", "exploring-oauth2-protocol-what-why-and-how"},
+		{"					Exploring OAuth2				 Protocol: What, Why, and How?		", "exploring-oauth2-protocol-what-why-and-how"},
+		{"Asynchronous Programming in JavaScript Ecosystem", "asynchronous-programming-in-javascript-ecosystem"},
+		{"<><><?><><)_(*&&^%^&%^$%#$%%^&(()##$%^&*(&", ""},
+		{"TROUBLE MAKER IS ON THE 666 W4Y", "trouble-maker-is-on-the-666-w4y"},
+		{"Wh  y  ? ev 3       erything    mu    s-t be not th e    best			         ", "wh-y-ev-3-erything-mu-st-be-not-th-e-best"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Should format: %s INTO %s", tc.input, tc.expected), func(t *testing.T) {
+			generated := utilService.FormatToURL(tc.input)
+
+			// if the value is Nil, then stop the test
+			require.NotNil(t, generated)
+
+			// assert if the value is as expected
+			assert.Equal(t, tc.expected, generated)
+		})
+	}
+}
+
 func TestGenerateRandomID(t *testing.T) {
 	t.Run("Should not return Nil or Empty", func(t *testing.T) {
 		generated := utilService.GenerateRandomID(8)


### PR DESCRIPTION
- [x] Add slug to Blog entity
- [x] Add slug as the only access to published blog detail
- [x] Private / preview still uses ID 
- [x] Add util function to convert title to slug
- [x] Add slug to blog when publish
- [x] Reset slug to blog when unpublish
- [x] Add unix time when found duplicaslug duplication within current user
- [x] Query all ID for sitemap should be in `/author/slug` format